### PR TITLE
LIBSEARCH-66. Modified code to URL encode search term

### DIFF
--- a/app/searchers/quick_search/swiftype_searcher.rb
+++ b/app/searchers/quick_search/swiftype_searcher.rb
@@ -38,7 +38,7 @@ module QuickSearch
 
     def parameters
       {
-        'q' => http_request_queries['not_escaped'],
+        'q' => http_request_queries['uri_escaped'],
         'per_page' => '3',
         'engine_key' => QuickSearch::Engine::SWIFTYPE_CONFIG['engine_key']
       }


### PR DESCRIPTION
Modified the code to use URL encoded (also know as "percent-encoding")
search terms for the HTTP request.

This ensures that search terms that include whitespace or quotes are
properly encoded for the request.

https://issues.umd.edu/browse/LIBSEARCH-66