### PR TITLE
LIBSEARCH-72. Changed user search query processing to be more permissive

### DIFF
--- a/app/searchers/quick_search/swiftype_searcher.rb
+++ b/app/searchers/quick_search/swiftype_searcher.rb
@@ -38,7 +38,7 @@ module QuickSearch
 
     def parameters
       {
-        'q' => http_request_queries['uri_escaped'],
+        'q' => sanitized_user_search_query,
         'per_page' => '3',
         'engine_key' => QuickSearch::Engine::SWIFTYPE_CONFIG['engine_key']
       }
@@ -49,7 +49,15 @@ module QuickSearch
     end
 
     def loaded_link
-      QuickSearch::Engine::SWIFTYPE_CONFIG['loaded_link'] + http_request_queries['uri_escaped']
+      QuickSearch::Engine::SWIFTYPE_CONFIG['loaded_link'] + sanitized_user_search_query
+    end
+
+    # Returns the sanitized search query entered by the user, skipping
+    # the default QuickSearch query filtering
+    def sanitized_user_search_query
+      # Need to use "to_str" as otherwise Japanese text isn't returned
+      # properly
+      sanitize(@q).to_str
     end
   end
 end


### PR DESCRIPTION
The default QuickSearch user search query processing is very
restrictive, and prevents some common searches, such as those with
dashes. There were also difficulties with using search terms in foreign
languages such as Japanese.

Added "sanitized_user_search_query" method to return the user search
query that has only been passed through the "sanitize" method, which
results in a broader range of queries than that allows the default
QuickSearch user search query processing.

It is possible that even the "sanitize" method is not needed, but is
used here for whatever marginal benefit it might provide.

https://issues.umd.edu/browse/LIBSEARCH-72